### PR TITLE
fix: 修復短期帳本臨時成員刪除功能與記帳權限錯誤

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -70,10 +70,13 @@ service cloud.firestore {
         allow read: if isApprovedUser() && isMemberOfGroup(groupId);
 
         // Only group members can create expenses
-        // Ensure payerUid is the authenticated user or a member
+        // Ensure payerUid is the authenticated user, a member, or a temporary member if the group is temporary
         allow create: if isApprovedUser() &&
-                         isMemberOfGroup(groupId) &&
-                         request.resource.data.payerUid in get(/databases/$(database)/documents/groups/$(groupId)).data.members;
+                          isMemberOfGroup(groupId) &&
+                          (
+                            request.resource.data.payerUid in get(/databases/$(database)/documents/groups/$(groupId)).data.members ||
+                            get(/databases/$(database)/documents/groups/$(groupId)).data.get('isTemporary', false) == true
+                          );
 
         // Only the expense creator or group members can update
         allow update: if isApprovedUser() && isMemberOfGroup(groupId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -488,7 +487,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -535,7 +533,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1202,7 +1199,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1269,7 +1265,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -1285,8 +1280,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.1",
@@ -1737,7 +1731,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2413,7 +2406,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2570,7 +2564,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2581,7 +2574,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2723,7 +2715,6 @@
       "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.15",
         "fflate": "^0.8.2",
@@ -2760,7 +2751,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2914,7 +2904,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3311,7 +3300,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.266",
@@ -3426,7 +3416,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3970,7 +3959,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -4315,6 +4303,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4536,7 +4525,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4564,7 +4552,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4590,6 +4577,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4605,6 +4593,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4617,7 +4606,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/protobufjs": {
       "version": "7.5.4",
@@ -4658,7 +4648,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4668,7 +4657,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4715,7 +4703,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4830,8 +4817,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5253,7 +5239,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5346,7 +5331,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5422,7 +5406,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -5754,7 +5737,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/hooks/useGroup.ts
+++ b/src/hooks/useGroup.ts
@@ -1,9 +1,13 @@
 import { useState, useEffect } from "react";
-import { doc, onSnapshot, updateDoc, arrayUnion, collection, getDocs, query, where } from "firebase/firestore";
+import { doc, onSnapshot, updateDoc, arrayUnion, arrayRemove, collection, getDocs, query, where } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import { Group, Member, UseGroupReturn } from "../types";
 
-export function useGroup(groupId: string): UseGroupReturn & { addMember: (uid: string) => Promise<void>; addTemporaryMember: (name: string) => Promise<void> } {
+export function useGroup(groupId: string): UseGroupReturn & {
+    addMember: (uid: string) => Promise<void>;
+    addTemporaryMember: (name: string) => Promise<void>;
+    removeTemporaryMember: (memberId: string) => Promise<void>;
+} {
     const [group, setGroup] = useState<Group | null>(null);
     const [members, setMembers] = useState<Member[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
@@ -100,5 +104,23 @@ export function useGroup(groupId: string): UseGroupReturn & { addMember: (uid: s
         }
     };
 
-    return { group, members, loading, addMember, addTemporaryMember };
+    const removeTemporaryMember = async (memberId: string): Promise<void> => {
+        try {
+            if (!group || !group.temporaryMembers) return;
+            const tempMemberToRemove = group.temporaryMembers.find(m => m.id === memberId);
+            if (!tempMemberToRemove) {
+                throw new Error("Temporary member not found in group");
+            }
+
+            await updateDoc(doc(db, "groups", groupId), {
+                temporaryMembers: arrayRemove(tempMemberToRemove)
+            });
+        } catch (err) {
+            console.error("Failed to remove temporary member:", err);
+            const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
+            throw new Error(`Failed to remove temporary member: ${errorMessage}`);
+        }
+    };
+
+    return { group, members, loading, addMember, addTemporaryMember, removeTemporaryMember };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -68,7 +68,9 @@
     "groupNotFound": "Group not found",
     "unknown": "Unknown",
     "uncategorized": "Uncategorized",
-    "expenseCount": "expense records"
+    "expenseCount": "expense records",
+    "memberHasExpensesWarning": "This member has existing expenses and cannot be deleted. Please delete or modify the associated expenses first.",
+    "confirmDeleteTemporaryMember": "Are you sure you want to delete temporary member {{name}}?"
   },
   "expense": {
     "add": "Add New Expense",
@@ -201,6 +203,7 @@
     "updateExpenseFailed": "Failed to update expense. Please try again.",
     "loadUsersFailed": "Failed to load user list. Please try again.",
     "updateUsersFailed": "Failed to update user permissions. Please try again.",
-    "deleteUserFailed": "Failed to delete user. Please try again."
+    "deleteUserFailed": "Failed to delete user. Please try again.",
+    "deleteMemberFailed": "Failed to delete member. Please try again."
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -68,7 +68,9 @@
     "groupNotFound": "找不到群组",
     "unknown": "未知",
     "uncategorized": "未分类",
-    "expenseCount": "笔消费明细"
+    "expenseCount": "笔消费明细",
+    "memberHasExpensesWarning": "此成员已有费用记录，无法删除。请先删除或修改相关费用。",
+    "confirmDeleteTemporaryMember": "确定要删除临时成员 {{name}} 吗？"
   },
   "expense": {
     "add": "添加费用",
@@ -201,6 +203,7 @@
     "updateExpenseFailed": "更新费用失败，请再试一次。",
     "loadUsersFailed": "加载用户列表失败，请重试。",
     "updateUsersFailed": "更新用户权限失败，请重试。",
-    "deleteUserFailed": "删除用户失败，请再试一次。"
+    "deleteUserFailed": "删除用户失败，请再试一次。",
+    "deleteMemberFailed": "删除成员失败，请重试。"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -68,7 +68,9 @@
     "groupNotFound": "找不到帳本",
     "unknown": "未知",
     "uncategorized": "未分類",
-    "expenseCount": "筆消費明細"
+    "expenseCount": "筆消費明細",
+    "memberHasExpensesWarning": "此成員已有費用記錄，無法刪除。請先刪除或修改相關費用。",
+    "confirmDeleteTemporaryMember": "確定要刪除臨時成員 {{name}} 嗎？"
   },
   "expense": {
     "add": "新增費用",
@@ -201,6 +203,7 @@
     "updateExpenseFailed": "更新費用失敗，請再試一次。",
     "loadUsersFailed": "載入使用者列表失敗，請重試。",
     "updateUsersFailed": "更新使用者權限失敗，請重試。",
-    "deleteUserFailed": "刪除使用者失敗，請再試一次。"
+    "deleteUserFailed": "刪除使用者失敗，請再試一次。",
+    "deleteMemberFailed": "刪除成員失敗，請重試。"
   }
 }

--- a/src/pages/GroupDetail.tsx
+++ b/src/pages/GroupDetail.tsx
@@ -51,7 +51,7 @@ export default function GroupDetail() {
 
     if (!groupId) return <div className="container text-center mt-10">{t('group.invalidGroupId')}</div>;
 
-    const { group, members, addMember, addTemporaryMember, loading: groupLoading } = useGroup(groupId);
+    const { group, members, addMember, addTemporaryMember, removeTemporaryMember, loading: groupLoading } = useGroup(groupId);
     const { expenses, addExpense, deleteExpense, updateExpense, loading: expensesLoading } = useExpenses(groupId);
 
     const [showAddExpense, setShowAddExpense] = useState(false);
@@ -69,6 +69,26 @@ export default function GroupDetail() {
         } catch (error) {
             console.error("Failed to delete expense:", error);
             alert(t('errors.deleteExpenseFailed'));
+        }
+    };
+ 
+    const handleDeleteTemporaryMember = async (memberId: string, displayName: string): Promise<void> => {
+        // Check if member has any associated expenses
+        const isPayer = expenses.some(e => e.payerUid === memberId);
+        const isInvolved = expenses.some(e => e.involvedUids?.includes(memberId));
+
+        if (isPayer || isInvolved) {
+            alert(t('group.memberHasExpensesWarning'));
+            return;
+        }
+
+        if (!window.confirm(t('group.confirmDeleteTemporaryMember', { name: displayName }))) return;
+
+        try {
+            await removeTemporaryMember(memberId);
+        } catch (error) {
+            console.error("Failed to delete temporary member:", error);
+            alert(t('errors.deleteMemberFailed'));
         }
     };
 
@@ -266,7 +286,7 @@ export default function GroupDetail() {
                     <div>
 
                         <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
-                            {members.map(m => (
+                             {members.map(m => (
                                 <div key={m.uid} className="flex-center" style={{
                                     background: "rgba(255,255,255,0.05)",
                                     padding: "0.5rem 1rem",
@@ -278,6 +298,33 @@ export default function GroupDetail() {
                                         <img src={m.photoURL} alt="" style={{ width: 20, height: 20, borderRadius: "50%" }} />
                                     ) : <div style={{ width: 20, height: 20, background: "gray", borderRadius: "50%" }} />}
                                     <span style={{ fontSize: "0.9rem" }}>{m.displayName}</span>
+                                    {m.isTemporary && (
+                                        <button
+                                            onClick={() => handleDeleteTemporaryMember(m.uid, m.displayName)}
+                                            style={{
+                                                background: "none",
+                                                border: "none",
+                                                color: "var(--text-muted)",
+                                                cursor: "pointer",
+                                                padding: "0.1rem",
+                                                display: "flex",
+                                                alignItems: "center",
+                                                borderRadius: "50%",
+                                                transition: "all 0.2s ease"
+                                            }}
+                                            onMouseEnter={(e) => {
+                                                e.currentTarget.style.color = "hsl(var(--color-danger))";
+                                                e.currentTarget.style.background = "rgba(239, 68, 68, 0.1)";
+                                            }}
+                                            onMouseLeave={(e) => {
+                                                e.currentTarget.style.color = "var(--text-muted)";
+                                                e.currentTarget.style.background = "none";
+                                            }}
+                                            title={t('common.delete')}
+                                        >
+                                            <X size={14} />
+                                        </button>
+                                    )}
                                 </div>
                             ))}
                         </div>


### PR DESCRIPTION
- [規則] 修改 firestore.rules：放寬短期帳本（isTemporary == true）的費用建立權限，允許付款人（payerUid）設定為臨時成員，修復記帳權限錯誤。
- [Hooks] 修改 useGroup.ts：加入並導出 removeTemporaryMember 方法，使用 arrayRemove 安全移除臨時成員。
- [頁面] 修改 GroupDetail.tsx：成員列表旁新增刪除（X）按鈕，點擊觸發確認；新增安全機制，若成員已有費用記錄則限制刪除以防止數據不一致。
- [多語言] 補全 zh-TW, zh-CN, en 多語言翻譯，新增刪除確認與記帳警告字串。
- [依賴] 更新 package-lock.json。